### PR TITLE
Fixes bug with quotes

### DIFF
--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -83,7 +83,7 @@
 			$label = Widget::Label();
 			$label->appendChild(
 				Widget::Input(
-					"fields[$element_name][$i][key]", $key, 'text', array('placeholder' => __('Key'))
+					"fields[$element_name][$i][key]", General::sanitize($key), 'text', array('placeholder' => __('Key'))
 				)
 			);
 			$li->appendChild($label);
@@ -92,7 +92,7 @@
 			$label = Widget::Label();
 			$label->appendChild(
 				Widget::Input(
-					"fields[$element_name][$i][value]", $value, 'text', array('placeholder' => __('Value'))
+					"fields[$element_name][$i][value]", General::sanitize($value), 'text', array('placeholder' => __('Value'))
 				)
 			);
 			$li->appendChild($label);


### PR DESCRIPTION
This commit fixes a bug when there is a quote-character used in the input-field.

At the moment, using a quote in the input field results in a malformed value, since the quote would be used as end-tag for the `value`-attribute of the `<input>`-element.
