### PR TITLE
Fix import

### DIFF
--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -356,7 +356,7 @@
 			$temp = array();
 
 			if($mode === $modes->getPostdata) {
-				return $this->processRawFieldData($data, $status, $message, true, $entry_id);
+				return $data;
 			}
 			else if($mode === $modes->getString) {
 				$data = preg_split('/,\s*/', $data[0], -1, PREG_SPLIT_NO_EMPTY);


### PR DESCRIPTION
Meta Keys expects arrays of key/value pairs that are processed by `processRawFieldData()` on import – the current code results in a loss of values because that function was already called before the actual import.