### PR TITLE
Advanced filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Meta Keys field allows you to add arbitrary pieces of information to entries
 
 ### Section
 #### Default Keys
+
 You can set a number of default keys in the Section Editor, these will appear when you first create an entry. If the default keys aren't filled with values,they will be removed with the duplicator upon saving.
 
 If you want to assign a default value to a key, use the `::` syntax. eg. `Colour::Red`, which will fill the Key with 'Colour' and the value with 'Red'.
@@ -19,19 +20,23 @@ If you want to assign a default value to a key, use the `::` syntax. eg. `Colour
 You can also prefill multiple keys with commas, ie. `Colour::Red, Size::Medium`. If you need to have a value that includes a comma, escape it, eg. `Colour::Red\\, Green`
 
 #### Validator
+
 The usual Symphony validation applies to the Values of your Keys.
 
 #### Required Field
+
 This settings ensures that you at least one completed Pair, the Key and Value, is filled.
 
 ### Datasources
 #### Named Keys vs. Keys
+
 You can choose between the named keys output, or just a generic key output for your XML. A named key will use the name of the key as the node name, whereas generic will just list each pair under a 'key' node.
 
 Consider the example of Colour: Red:
 
 Normal mode:
-```
+
+```xml
   <field mode='normal'>
     <key handle='colour' name='Colour'>
       <value hande='red'>Red</value>
@@ -40,7 +45,8 @@ Normal mode:
 ```
 
 Named key mode:
-```
+
+```xml
   <field mode='named-keys'>
     <colour handle='colour' name='Colour'>
       <value handle='red'>Red</value>
@@ -49,25 +55,51 @@ Named key mode:
 ```
 
 #### Filtering
+
 Best efforts have been made for these to support normal Symphony enumerators of `+`,`,` and `:`, but please report any unusual behaviour!
 
-##### `colour`
+##### Filter by key (default)
+
+```
+colour
+```
+
 Normal default filtering without any `*:` conditions will search on keys. This will return all the entries where a key of `colour` exists (whether it has a value or not).
 
-##### `value: red`
-This will return all entries where one Pair exists that has the value of red.
+##### Filter by values
 
-##### `key-equals: colour=red`
+```
+value: red
+```
+
+This will return all entries where one pair exists that has the value of `red`.
+
+
+##### Filter by exact key/value pair
+
+```
+key-equals: colour=red
+```
+
 This will return all entries where the `Colour` key equals `red`. You can chain this as well with `key-equals: colour=red, shape=square` that will get all entries where the `Colour` is `red` and the `Shape` is `square`.
 
-##### `price: 1..5`
-Returns all entries where the value of the key `price` is between 1 and 5 (inclusive)
+##### Filter by exact key/value pair
 
-##### `price: ...5`
-Returns all entries where the value of the key `price` is less than 5 (inclusive)
+```
+key-contains: colour=red
+```
 
-##### `price: 5...`
-Returns all entries where the value of the key `price` is more than 5 (inclusive).
+This will return all entries where the `Colour` key contains the word `red`, e. g. it matches `red` in `blue, green, red`. You can chain this as well with `key-contains: colour=red, shape=square` that will get all entries where `Colour` contains the word `red` and `Shape` contains `square`.
+
+##### Filter by value range
+
+```
+key-ranges: 5..10
+key-ranges: 5...
+key-ranges: ...10
+```
+
+Return all entries where the value in between the given range. An additional third dot allows "more than" (`5...`) or "less than" (`...10`) queries.
 
 ## XMLImporter support
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Best efforts have been made for these to support normal Symphony enumerators of 
 
 ##### Filter by key (default)
 
-```
+```yaml
 colour
 ```
 
@@ -68,7 +68,7 @@ Normal default filtering without any `*:` conditions will search on keys. This w
 
 ##### Filter by values
 
-```
+```yaml
 value: red
 ```
 
@@ -77,7 +77,7 @@ This will return all entries where one pair exists that has the value of `red`.
 
 ##### Filter by exact key/value pair
 
-```
+```yaml
 key-equals: colour=red
 ```
 
@@ -85,7 +85,7 @@ This will return all entries where the `Colour` key equals `red`. You can chain 
 
 ##### Filter by exact key/value pair
 
-```
+```yaml
 key-contains: colour=red
 ```
 
@@ -93,7 +93,7 @@ This will return all entries where the `Colour` key contains the word `red`, e. 
 
 ##### Filter by value range
 
-```
+```yaml
 key-ranges: 5..10
 key-ranges: 5...
 key-ranges: ...10

--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -159,7 +159,7 @@
 			// Automatic delete
 			$label = Widget::Label(null, null, 'column');
 			$input = Widget::Input('fields['.$order.'][delete_empty_keys]', 'yes', 'checkbox');
-			
+
 			if ($this->get('delete_empty_keys') == '1') $input->setAttribute('checked', 'checked');
 
 			$label->setValue(__('%s Automatically delete empty keys', array($input->generate())));
@@ -268,7 +268,7 @@
 
 		public function checkPostFieldData($data, &$message, $entry_id = null) {
 			// Check required
-			if($this->get('required') == 'yes' && (!isset($data[0]['key']) || empty($data[0]['value']))) {
+			if($this->get('required') == 'yes' && (!isset($data[0]['key']) || General::strlen($data[0]['value']) == 0)) {
 				$message = __(
 					"'%s' is a required field.", array(
 						$this->get('label')
@@ -279,7 +279,7 @@
 			}
 
 			// Return if it's allowed to be empty (and is empty)
-			if(empty($data[0]['value'])) return self::__OK__;
+			if(General::strlen($data[0]['value']) == 0) return self::__OK__;
 
 			// Process Validation Rules
 			if (!$this->applyValidationRules($data)) {
@@ -306,7 +306,7 @@
 				// Key is not empty AND
 				// Value is not empty OR we don't want to delete empty pairs
 				// Then skip adding that pair in the result
-				if(!empty($pair['key']) && (!empty($pair['value']) || $delete_empty_keys == false)) {
+				if(!empty($pair['key']) && (General::strlen($pair['value']) > 0 || $delete_empty_keys == false)) {
 					$result['key_handle'][$i] = Lang::createHandle($pair['key']);
 					$result['key_value'][$i] = $pair['key'];
 					$result['value_handle'][$i] = Lang::createHandle($pair['value']);

--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -517,7 +517,7 @@
 				$this->buildFilterByKeyEqualsQuery($data, $joins, $where);
 			}
 
-			// Filter by exact key/value pair
+			// Filter by key/value pair
 			elseif (strpos($data[0], 'key-contains:') === 0) {
 				$data = $this->getCleanValues($data, 'key-contains:');
 				$this->buildFilterByKeyContainsQuery($data, $joins, $where);

--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -356,7 +356,7 @@
 			$temp = array();
 
 			if($mode === $modes->getPostdata) {
-				return $this->processRawFieldData($data, $status, $message, true, $entry_id);
+				return $data;
 			}
 			else if($mode === $modes->getString) {
 				$data = preg_split('/,\s*/', $data[0], -1, PREG_SPLIT_NO_EMPTY);

--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -307,10 +307,10 @@
 				// Value is not empty OR we don't want to delete empty pairs
 				// Then skip adding that pair in the result
 				if(!empty($pair['key']) && (General::strlen($pair['value']) > 0 || $delete_empty_keys == false)) {
-					$result['key_handle'][$i] = Lang::createHandle($pair['key']);
-					$result['key_value'][$i] = $pair['key'];
-					$result['value_handle'][$i] = Lang::createHandle($pair['value']);
-					$result['value_value'][$i] = $pair['value'];
+					$result['key_handle'][] = Lang::createHandle($pair['key']);
+					$result['key_value'][] = $pair['key'];
+					$result['value_handle'][] = Lang::createHandle($pair['value']);
+					$result['value_value'][] = $pair['value'];
 				}
 			}
 

--- a/fields/field.metakeys.php
+++ b/fields/field.metakeys.php
@@ -279,7 +279,7 @@
 			}
 
 			// Return if it's allowed to be empty (and is empty)
-			if(General::strlen($data[0]['value']) == 0) return self::__OK__;
+			if(isset($data[0]['value']) && General::strlen($data[0]['value']) == 0) return self::__OK__;
 
 			// Process Validation Rules
 			if (!$this->applyValidationRules($data)) {


### PR DESCRIPTION
This is something for @brendo to review:

- Introduces better range filtering. It's a breaking change because range filters now require a prefix (`key-ranges`) but it makes the filtering logic more consistent in my eyes. The field values matched by the filter can either be single values or ranges.

>     key-ranges: 5..10
>     key-ranges: 5...
>     key-ranges: ...10
>
> Return all entries where the value in between the given range. An additional third dot allows "more than" (5...) or "less than" (...10) queries.

- Adds a new filter `key-contains`:

>     key-contains: colour=red
>
> This will return all entries where the Colour key contains the word red, e. g. it matches red in blue, green, red. You can chain this as well with key-contains: colour=red, shape=square that will get all entries where Colour contains the word red and Shape contains square.

- With this pull request, the extension allows filtering using different filtering methods (`key-equals`, `key-ranges`…) if the filters are joined with and `+` (`AND`).

The pull request also feature fixes for imports and zero value handling (by @jurajkapsz) that have been discussed here already.

---

I tried to organise the filtering functions a bit in order to understand how things work. The filtering itself is a result of trial and error but everything seems to work just fine. I'm not sure if the changes fit into your concept but I thought I'd submit a pull request never the less. 